### PR TITLE
Fix downloader failures on amateur videos, update cookies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ failed_ids_file = failed_ids.txt     # Failed IDs tracking file
 #### [Network] Section
 ```ini
 user_agent = Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html) #Don't touch this, it's required to bypass VPN requirement.
-cookie = age_check_done=1; INT_SESID=YOUR-SESSION-ID; licenseUID=YOUR-LICENSE-ID  # **IMPORTANT: Replace with your actual DMM cookie values**
+cookie = age_check_done=1;INT_SESID=xxx;secid=xxx;login_secure_id=xxx;login_session_id=xxx;licenseUID=xxx  # **IMPORTANT: Replace XXX with your actual DMM cookie values**
 http_proxy =                         # HTTP proxy server (optional) - e.g., http://proxy.company.com:8080
 https_proxy =                        # HTTPS proxy server (optional) - e.g., https://proxy.company.com:8080
 ```


### PR DESCRIPTION
## Summary

This PR fixes an issue where `downloader.py` failed on amateur videos.
It also updates the default cookie configuration and improves the README
to reflect the required cookie format.

## Changes

- Fixed downloader logic so amateur videos are handled correctly
- Updated default cookie format to include all required session values
- Updated README with correct cookie instructions

## Notes

- No breaking changes to existing configuration
- Tested against amateur and non-amateur videos